### PR TITLE
Add initial implementation of tfcount CLI to summarize terraform plan…

### DIFF
--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -1,0 +1,93 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/spf13/cobra"
+)
+
+var planCMD = &cobra.Command{
+	Use:   "plan",
+	Short: "Run terraform plan and summarize the changes",
+	Run: func(cmd *cobra.Command, args []string) {
+		runTerraformPlan()
+	},
+}
+
+func init() {
+	// register the plan command under root
+	rootCmd.AddCommand(planCMD)
+}
+
+func runTerraformPlan() {
+
+	// step 1: Run terraform plan -out-tfplan.out
+	fmt.Println("Running terraform plan...")
+	planCMD := exec.Command("terraform", "plan", "-out=tfplan.out")
+	planCMD.Stdout = os.Stdout
+	planCMD.Stderr = os.Stderr
+
+	if err := planCMD.Run(); err != nil {
+		fmt.Printf("Error running the terraform plan: %v\n", err)
+		return
+	}
+
+	// step 2: Run terraform show -json tfplan.out
+	fmt.Println("Running terraform show...")
+	showCMD := exec.Command("terraform", "show", "-json", "tfplan.out")
+	var stdout bytes.Buffer
+	showCMD.Stdout = &stdout
+
+	if err := showCMD.Run(); err != nil {
+		fmt.Printf("Error running the terraform show: %v\n", err)
+		return
+	}
+
+	// step 3: Parse the JSON output
+	var tfPlan TerraformPlan
+	if err := json.Unmarshal(stdout.Bytes(), &tfPlan); err != nil {
+		fmt.Printf("Error parsing the terraform plan JSON: %v\n", err)
+		return
+	}
+
+	// step 4: Summarize by resource type and action
+	counts := make(map[string]map[string]int)
+	for _, rc := range tfPlan.ResourceChanges {
+		// fmt.Printf("Resource change: %v\n\n", rc)
+		resourceType := rc.Type
+
+		for _, action := range rc.Change.Actions {
+			if counts[resourceType] == nil {
+				counts[resourceType] = make(map[string]int)
+			}
+
+			counts[resourceType][action]++
+		}
+	}
+
+	// step 5: Print resource change summary
+	fmt.Println("\n📊 Resource Change Summary:")
+	for resType, actions := range counts {
+		fmt.Printf("- %s:\n", resType)
+		for action, count := range actions {
+			symbol := map[string]string{"create": "+", "update": "~", "delete": "-"}[action]
+			fmt.Printf("    %s %s: %d\n", symbol, action, count)
+		}
+	}
+
+	// Optional cleanup
+	_ = os.Remove("tfplan.out")
+}
+
+type TerraformPlan struct {
+	ResourceChanges []struct {
+		Type   string `json:"type"`
+		Change struct {
+			Actions []string `json:"actions"`
+		} `json:"change"`
+	} `json:"resource_changes"`
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// represent the root command of cli application
+var rootCmd = &cobra.Command{
+	Use:   "tfcount",
+	Short: "A simple CLI to summarize terraform plan outputs by resource type and action",
+	Run: func(cmd *cobra.Command, args []string) {
+		// logic for root cmd
+	},
+}
+
+// entrypoint for the CLI
+func Execute() {
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,9 @@
+module tfcount
+
+go 1.24.4
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/cobra v1.9.1 // indirect
+	github.com/spf13/pflag v1.0.6 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
+github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
+github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
+github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"tfcount/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}


### PR DESCRIPTION
This pull request introduces a new CLI tool called `tfcount`, designed to summarize Terraform plan outputs by resource type and action. The changes include the implementation of core functionality, CLI command structure, and dependency setup.

### Core Functionality:
* Implemented the `plan` command in `cmd/plan.go` to execute `terraform plan` and `terraform show`, parse the JSON output, and summarize resource changes by type and action. The summary includes counts of create, update, and delete actions, represented with symbols (`+`, `~`, `-`).