### PR TITLE
Remove unnecessary debug print statement from runTerraformPlan function

### DIFF
--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -69,7 +69,6 @@ func runTerraformPlan() {
 		for _, action := range rc.Change.Actions {
 			if action != "no-op" {
 				if counts[resourceType] == nil {
-					fmt.Println("inside second if block")
 					counts[resourceType] = make(map[string]int)
 				}
 				counts[resourceType][action]++


### PR DESCRIPTION
This pull request makes a minor change to the `runTerraformPlan` function in the `cmd/plan.go` file. It removes an unnecessary debug statement (`fmt.Println("inside second if block")`) to clean up the code.