### PR TITLE
Fix formatting in name_template for version in .goreleaser.yaml

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -20,7 +20,7 @@ archives:
   - formats: [tar.gz]
     name_template: >-
       {{ .ProjectName }}_
-      {{ .Version }}_
+      {{- .Version }}_
       {{- title .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386


### PR DESCRIPTION
This pull request includes a small formatting change to the `.goreleaser.yaml` file. The change adjusts the whitespace handling for the `{{ .Version }}` template by adding a leading dash to the template expression, ensuring consistent formatting.