### PR TITLE
Refactor command descriptions and add version flag handling in root cmd

### DIFF
--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -14,7 +14,7 @@ import (
 var useTerragrunt bool
 var planCMD = &cobra.Command{
 	Use:   "plan",
-	Short: "Run terraform plan and summarize the changes",
+	Short: "Run plan and summarize the changes",
 	Run: func(cmd *cobra.Command, args []string) {
 		runTerraformPlan()
 	},
@@ -22,6 +22,7 @@ var planCMD = &cobra.Command{
 
 func init() {
 	// register the plan command under root
+	rootCmd.PersistentFlags().BoolVarP(&showVersion, "version", "v", false, "Print the version and exit")
 	rootCmd.AddCommand(planCMD)
 	planCMD.Flags().BoolVar(&useTerragrunt, "terragrunt", false, "Use terragrunt instead of terraform")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,11 +8,19 @@ import (
 )
 
 // represent the root command of cli application
+var showVersion bool
+var Version = "dev"
 var rootCmd = &cobra.Command{
 	Use:   "tfcount",
-	Short: "A simple CLI to summarize terraform plan outputs by resource type and action",
+	Short: "A simple CLI to summarize terraform/terragrunt plan outputs by resource type and action",
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		if showVersion {
+			fmt.Println("tfcount", Version)
+			os.Exit(0)
+		}
+	},
 	Run: func(cmd *cobra.Command, args []string) {
-		// logic for root cmd
+		cmd.Help()
 	},
 }
 


### PR DESCRIPTION
This pull request introduces a new feature to display the version of the CLI tool and updates command descriptions for better clarity. The key changes include adding a `--version` flag to display the version, modifying command descriptions to include references to Terragrunt, and implementing logic to handle the version flag in the root command.

### New Feature: Version Display

* [`cmd/root.go`](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR11-R23): Added a `--version` (`-v`) flag to the CLI tool, which displays the current version (`Version` variable) when invoked and exits immediately.
* [`cmd/plan.go`](diffhunk://#diff-5321028a9d3baf80d66e6a307be4123e613fcfb8fac4d76cf7161d2da7ae754cL17-R25): Registered the `--version` flag as a persistent flag for the root command.

### Command Description Updates

* [`cmd/plan.go`](diffhunk://#diff-5321028a9d3baf80d66e6a307be4123e613fcfb8fac4d76cf7161d2da7ae754cL17-R25): Updated the `Short` description of the `plan` command to remove "terraform" and make it more generic.
* [`cmd/root.go`](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR11-R23): Updated the `Short` description of the root command to include references to both Terraform and Terragrunt.…ommand