### PR TITLE
feat: Add table format output support with --table flag

### DIFF
--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -316,6 +316,12 @@ func getActionSymbolAndColor(action string) (string, func(string) string) {
 	case "delete":
 		red := color.New(color.FgRed).SprintFunc()
 		return red("-"), func(s string) string { return s }
+	case "replace":
+		magenta := color.New(color.FgMagenta).SprintFunc()
+		return magenta("±"), func(s string) string { return s }
+	case "read":
+		blue := color.New(color.FgBlue).SprintFunc()
+		return blue("○"), func(s string) string { return s }
 	default:
 		cyan := color.New(color.FgCyan).SprintFunc()
 		return cyan("?"), func(s string) string { return s }

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -6,13 +6,16 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"sort"
 	"strings"
 
 	"github.com/fatih/color"
+	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 )
 
 var useTerragrunt bool
+var useTableFormat bool
 
 var planCMD = &cobra.Command{
 	Use:   "plan [-- tool-args...]",
@@ -32,6 +35,7 @@ func init() {
 	// register the plan command under root
 	rootCmd.AddCommand(planCMD)
 	planCMD.Flags().BoolVarP(&useTerragrunt, "terragrunt", "g", false, "To use terragrunt")
+	planCMD.Flags().BoolVarP(&useTableFormat, "table", "t", true, "Display output in table format (default: true)")
 }
 
 // runPlan orchestrates the entire plan process
@@ -186,12 +190,114 @@ func displaySummary(counts map[string]map[string]int) {
 		return
 	}
 
+	if useTableFormat {
+		displayTableSummary(counts)
+	} else {
+		displayPlainSummary(counts)
+	}
+}
+
+// displayTableSummary displays the summary in a table format
+func displayTableSummary(counts map[string]map[string]int) {
+	fmt.Println("📊 Resource Change Summary:")
+	fmt.Println()
+
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetHeader([]string{"Resource Type", "Action", "Count", "Symbol"})
+	table.SetBorder(true)
+	table.SetRowLine(true)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
+	table.SetHeaderAlignment(tablewriter.ALIGN_CENTER)
+	table.SetColumnAlignment([]int{tablewriter.ALIGN_LEFT, tablewriter.ALIGN_CENTER, tablewriter.ALIGN_CENTER, tablewriter.ALIGN_CENTER})
+
+	// Set colors for different parts of the table
+	table.SetHeaderColor(
+		tablewriter.Colors{tablewriter.Bold, tablewriter.FgCyanColor},
+		tablewriter.Colors{tablewriter.Bold, tablewriter.FgCyanColor},
+		tablewriter.Colors{tablewriter.Bold, tablewriter.FgCyanColor},
+		tablewriter.Colors{tablewriter.Bold, tablewriter.FgCyanColor},
+	)
+
+	// Collect and sort data for consistent output
+	type tableRow struct {
+		resourceType string
+		action       string
+		count        int
+		symbol       string
+		color        tablewriter.Colors
+	}
+
+	var rows []tableRow
+
+	// Get sorted resource types for consistent ordering
+	var resourceTypes []string
+	for resourceType := range counts {
+		resourceTypes = append(resourceTypes, resourceType)
+	}
+	sort.Strings(resourceTypes)
+
+	for _, resourceType := range resourceTypes {
+		actions := counts[resourceType]
+
+		// Get sorted actions for consistent ordering
+		var actionNames []string
+		for action := range actions {
+			actionNames = append(actionNames, action)
+		}
+		sort.Strings(actionNames)
+
+		for _, action := range actionNames {
+			count := actions[action]
+			symbol, colorCodes := getActionSymbolAndTableColor(action)
+
+			rows = append(rows, tableRow{
+				resourceType: resourceType,
+				action:       action,
+				count:        count,
+				symbol:       symbol,
+				color:        colorCodes,
+			})
+		}
+	}
+
+	// Add rows to table with colors
+	for _, row := range rows {
+		table.Rich([]string{row.resourceType, row.action, fmt.Sprintf("%d", row.count), row.symbol},
+			[]tablewriter.Colors{
+				{},        // Resource type - no color
+				row.color, // Action - colored based on action type
+				{},        // Count - no color  
+				row.color, // Symbol - colored based on action type
+			})
+	}
+
+	table.Render()
+}
+
+// displayPlainSummary displays the summary in plain text format (original format)
+func displayPlainSummary(counts map[string]map[string]int) {
 	fmt.Println("📊 Resource Change Summary:")
 
-	for resourceType, actions := range counts {
+	// Get sorted resource types for consistent ordering
+	var resourceTypes []string
+	for resourceType := range counts {
+		resourceTypes = append(resourceTypes, resourceType)
+	}
+	sort.Strings(resourceTypes)
+
+	for _, resourceType := range resourceTypes {
+		actions := counts[resourceType]
 		fmt.Printf("%s:\n", resourceType)
 
-		for action, count := range actions {
+		// Get sorted actions for consistent ordering  
+		var actionNames []string
+		for action := range actions {
+			actionNames = append(actionNames, action)
+		}
+		sort.Strings(actionNames)
+
+		for _, action := range actionNames {
+			count := actions[action]
 			symbol, colorFunc := getActionSymbolAndColor(action)
 			fmt.Printf("    %s %s: %d\n", symbol, colorFunc(action), count)
 		}
@@ -213,6 +319,24 @@ func getActionSymbolAndColor(action string) (string, func(string) string) {
 	default:
 		cyan := color.New(color.FgCyan).SprintFunc()
 		return cyan("?"), func(s string) string { return s }
+	}
+}
+
+// getActionSymbolAndTableColor returns the symbol and table color for an action
+func getActionSymbolAndTableColor(action string) (string, tablewriter.Colors) {
+	switch action {
+	case "create":
+		return "+", tablewriter.Colors{tablewriter.Bold, tablewriter.FgGreenColor}
+	case "update":
+		return "~", tablewriter.Colors{tablewriter.Bold, tablewriter.FgYellowColor}
+	case "delete":
+		return "-", tablewriter.Colors{tablewriter.Bold, tablewriter.FgRedColor}
+	case "replace":
+		return "±", tablewriter.Colors{tablewriter.Bold, tablewriter.FgMagentaColor}
+	case "read":
+		return "○", tablewriter.Colors{tablewriter.Bold, tablewriter.FgBlueColor}
+	default:
+		return "?", tablewriter.Colors{tablewriter.Bold, tablewriter.FgCyanColor}
 	}
 }
 

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -15,7 +15,7 @@ import (
 )
 
 var useTerragrunt bool
-var useTableFormat bool
+var outputFormat string
 
 var planCMD = &cobra.Command{
 	Use:   "plan [-- tool-args...]",
@@ -35,11 +35,16 @@ func init() {
 	// register the plan command under root
 	rootCmd.AddCommand(planCMD)
 	planCMD.Flags().BoolVarP(&useTerragrunt, "terragrunt", "g", false, "To use terragrunt")
-	planCMD.Flags().BoolVarP(&useTableFormat, "table", "t", true, "Display output in table format (default: true)")
+	planCMD.Flags().StringVarP(&outputFormat, "output", "o", "table", "Output format: 'table' (tabular view) or 'tree' (hierarchical view)")
 }
 
 // runPlan orchestrates the entire plan process
 func runPlan(extraArgs []string) error {
+	// Validate output format
+	if outputFormat != "table" && outputFormat != "tree" {
+		return fmt.Errorf("invalid output format '%s'. Supported formats: 'table', 'tree'", outputFormat)
+	}
+
 	binary := getBinary()
 
 	// Step 1: Generate plan file and get the filename used
@@ -190,10 +195,14 @@ func displaySummary(counts map[string]map[string]int) {
 		return
 	}
 
-	if useTableFormat {
+	switch outputFormat {
+	case "table":
 		displayTableSummary(counts)
-	} else {
+	case "tree":
 		displayPlainSummary(counts)
+	default:
+		fmt.Printf("Warning: Unknown output format '%s'. Using table format.\n", outputFormat)
+		displayTableSummary(counts)
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.24.4
 
 require (
 	github.com/fatih/color v1.18.0
+	github.com/olekukonko/tablewriter v0.0.5
 	github.com/spf13/cobra v1.9.1
 )
 
@@ -11,6 +12,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/mattn/go-runewidth v0.0.9 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
 	golang.org/x/sys v0.25.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,10 @@ github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovk
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
+github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
+github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
 github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=


### PR DESCRIPTION
Examples:

Table format (default)
tfcount plan

Explicit table format
tfcount plan --table=true

Plain text format (original)  
tfcount plan --table=false

With terragrunt
tfcount plan --terragrunt --table

Expected Output Comparison:

New Table Format:

Resource Change Summary:

+----------------+--------+-------+--------+
| RESOURCE TYPE  | ACTION | COUNT | SYMBOL |
+----------------+--------+-------+--------+
| aws_instance   | create |   2   |   +    |
| aws_instance   | update |   1   |   ~    |
| aws_s3_bucket  | create |   1   |   +    |
| aws_s3_bucket  | delete |   1   |   -    |
+----------------+--------+-------+--------+

Original Plain Text Format:

Resource Change Summary:
aws_instance:
    + create: 2
    ~ update: 1
aws_s3_bucket:
    + create: 1  
    - delete: 1